### PR TITLE
Set initial sequence number to one, as 0 is non-positive

### DIFF
--- a/java/session/src/se/pitch/oss/fedpro/common/session/SequenceNumber.java
+++ b/java/session/src/se/pitch/oss/fedpro/common/session/SequenceNumber.java
@@ -38,7 +38,7 @@ public class SequenceNumber {
    */
    public static final int NO_SEQUENCE_NUMBER = Integer.MIN_VALUE;
    public static final int MAX_SEQUENCE_NUMBER = Integer.MAX_VALUE;
-   public static final int INITIAL_SEQUENCE_NUMBER = 0;
+   public static final int INITIAL_SEQUENCE_NUMBER = 1;
 
    private int _value;
 


### PR DESCRIPTION
When trying to get this repository working, at TNO we ran into the following issue with Pitch Federate Protocol Server 5.5.9:

```
Exception in thread "SessionServer Thread for /172.29.33.27:35610" java.lang.IllegalArgumentException: Sequence number argument must be positive
        at se.pitch.fedpro.common.session.SequenceNumber.validateArgument(SequenceNumber.java:152)
        at se.pitch.fedpro.common.session.SequenceNumber.<init>(SequenceNumber.java:36)
        at se.pitch.fedpro.common.session.AtomicSequenceNumber.<init>(AtomicSequenceNumber.java:14)
        at se.pitch.fedpro.server.session.ServerSessionImpl.<init>(FedProSession_b8021.map:59)
        at se.pitch.fedpro.server.session.SessionInitializer.ctrlNewSession(FedProSession_b8021.map:103)
        at se.pitch.fedpro.server.session.SessionInitializer.readMessage(FedProSession_b8021.map:59)
        at se.pitch.fedpro.server.session.SessionInitializer.initializeSession(FedProSession_b8021.map:42)
        at se.pitch.fedpro.server.session.SessionServerImpl.b(FedProSession_b8021.map:103)
        at se.pitch.fedpro.server.session.SessionServerImpl.a(FedProSession_b8021.map:88)
        at se.pitch.fedpro.server.transport.ServerTransportBase.a(FedProSession_b8021.map:133)
        at se.pitch.fedpro.server.transport.ServerTransportBase.c(FedProSession_b8021.map:58)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

The solution seems to be to start at one.

I guess one can debate whether zero is a positive number or not, but it feels a bit strange that Pitch Federate Protocol Server 5.5.9 doesn't accept zero. But starting at one also doesn't hurt anyone, and at least this way the examples in this project work :)

PS: the protobuf in this repository in general is not compatible with Pitch Federate Protocol Server 5.5.9, but at least this gets the beginning running.